### PR TITLE
Implement `Eq` for `Face`

### DIFF
--- a/src/face.rs
+++ b/src/face.rs
@@ -1,4 +1,4 @@
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 /// This enum represents all the faces of a cubic voxel.
 pub enum Face {
     Top,


### PR DESCRIPTION
Adds `Eq` impl for `Face` so we can do things like:
```rs
enum MyBlock {
    None,
    Cube,
    Pyramid { base: Face },
}

fn is_covering(&self, &voxel: &Self::Voxel, neighbor: Face) -> bool {
    match voxel {
        MyBlock::None => false,
        MyBlock::Cube => true,
        MyBlock::Pyramid { base } => base == neighbor,
    }
}
```
`matches!` *works* but is less ergonomic, especially since it ruins `#[derive(PartialEq, Eq)]` for `MyBlock`.