### PR TITLE
Update to Bevy 0.15, fix grammar and formatting

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,101 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'bevy_meshem'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=bevy_meshem"
+                ],
+                "filter": {
+                    "name": "bevy_meshem",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug example 'simple_example'",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--example=simple_example",
+                    "--package=bevy_meshem"
+                ],
+                "filter": {
+                    "name": "simple_example",
+                    "kind": "example"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in example 'simple_example'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--example=simple_example",
+                    "--package=bevy_meshem"
+                ],
+                "filter": {
+                    "name": "simple_example",
+                    "kind": "example"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug example 'update_mesh_example'",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--example=update_mesh_example",
+                    "--package=bevy_meshem"
+                ],
+                "filter": {
+                    "name": "update_mesh_example",
+                    "kind": "example"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in example 'update_mesh_example'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--example=update_mesh_example",
+                    "--package=bevy_meshem"
+                ],
+                "filter": {
+                    "name": "update_mesh_example",
+                    "kind": "example"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        }
+    ]
+}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,5 @@ documentation = "https://docs.rs/bevy_meshem"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = "0.13.0"
+bevy = "0.15.0"
 rand = "0.8.5"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Bevy Meshem
+
 ## ***Showcase (taken from [minecraft_bevy](https://github.com/Adamkob12/minecraft_bevy)):***
+
 ![Screenshot 2023-11-05 at 16 41 53](https://github.com/Adamkob12/bevy_meshem/assets/46227443/58afd45b-ea66-4b77-a3b1-d00627bd27a5)
 
 Bevy Compatibility:
@@ -15,24 +17,35 @@ Similar to the mechanics in Minecraft, Bevy Meshem offers a powerful and flexibl
 Currently in pre-release stages of development.
 
 ## Features
-### ___Generate 3d meshes:___
+
+### ***Generate 3d meshes:***
+
 Just define a data structure that implements the simple "VoxelRegistry" trait (see examples and documentation) and you can turn any array of voxels into a 3d mesh.
-### ___Run time mesh updating in O(1):___
-Added in 0.2, this features allows users to easily update the mesh after it has been generated, without any need for regenerating. See the new update_mesh_example.
+
+### ***Run time mesh updating in O(1):***
+
+Added in 0.2, this feature allows users to easily update the mesh after it has been generated, without any need for regenerating. See the new update_mesh_example.
 ![update mesh video](assets/Screenshots/video1.gif)
-### ___Custom Shadowing, Similar to "Ambient Occlusion" (Smooth Lighting)___
-Added in 0.3, this feature allowes users to add an ambient occlusion-like effect during mesh generation, "Smooth Lighting":
+
+### ***Custom Shadowing, Similar to "Ambient Occlusion" (Smooth Lighting)***
+
+Added in 0.3, this feature allows users to add an ambient occlusion-like effect during mesh generation, "Smooth Lighting":
 ![Screenshot 2023-11-05 at 16 36 06](https://github.com/Adamkob12/bevy_meshem/assets/46227443/6bc24f3e-d223-4cab-8128-33a3fb9f1bd8)
-### ___"Introducing" Chunks___
-When generating each mesh, the unused vertices inside the mesh are being culled, but there was no way to automatically cull vertices trapped between two seperatly generated meshes, only manually.
+
+### ***"Introducing" Chunks***
+
+When generating each mesh, the unused vertices inside the mesh are being culled, but there was no way to automatically cull vertices trapped between two separately generated meshes, only manually.
 Now `introduce_adjacent_chunks` will automatically do the job for you, and apply the shadowing mentioned above as well!
+
 ### "The Naive Method"
-Iterate over the grid and generate a matching cube for each voxel (Also reffered to as the "default" as this method doesn't offer any optimization) examples: (screenshots from examples/simple_example.rs)
+
+Iterate over the grid and generate a matching cube for each voxel (Also referred to as the "default" as this method doesn't offer any optimization) examples: (screenshots from examples/simple_example.rs)
 ![Naive method screenshot](assets/Screenshots/ScreenshotS.png)
 
 10x10x10 grid, each voxel is built out of 24 vertices, and the entire mesh is built out of 24000 (expected, 24 * 10 * 10 * 10)
 
 ### "Culling"
+
 A slightly more sophisticated method, while iterating over the grid, we don't add any vertices and indices that are hidden behind other voxels. This is roughly the method that Minecraft uses in its
 engine, though the specifics are obviously unknown. examples:
 ![Culling method screenshot](assets/Screenshots/ScreenshotC.png)
@@ -40,17 +53,21 @@ engine, though the specifics are obviously unknown. examples:
 10x10x10 grid, but in contrast to The Naive Method, only 2400 are rendered.
 
 ### Not supported: "Greedy Meshing"
-Greedy Meshing is even more effecient than Culling, but it makes very limiting compromises (specifically to the texture of the mesh), making it somewhat undesirable. Support for this method might be added in later stages.
+
+Greedy Meshing is even more efficient than Culling, but it makes very limiting compromises (specifically to the texture of the mesh), making it somewhat undesirable. Support for this method might be added in later stages.
 
 ## Requirements & Installation
-- You must be familliar with the Bevy game engine, and of course the Rust programming language.
+
+- You must be familiar with the Bevy game engine, and of course the Rust programming language.
 - You know the drill - add this incantation to your project's Cargo.toml file:
+
   ```toml
   [dependencies]
   bevy_meshem = "0.3"
   ```
 
 ## Usage
+
 The example in examples/simple_example.rs shows what you need to do to get started.
 
 ***In 0.1, you provide a VoxelRegistry and a grid of voxels, and you get a mesh.***
@@ -62,14 +79,16 @@ The example in examples/simple_example.rs shows what you need to do to get start
 <img width="615" alt="Screenshot 2023-09-28 at 22 05 47" src="https://github.com/Adamkob12/bevy_meshem/assets/46227443/bc8459ad-d6ea-4eef-8677-c2b7688db1e9">
 
 ## Design Goals
-Flexibillity, Stabillity, User experience and Performance.
+
+Flexibility, Stability, User experience and Performance.
 
 ## Contributing
+
 Contributions are very welcome! This project is currently in its early stages and operates closely with the Bevy rendering API.
 As a result, it may have some stability challenges. However, your contributions can play a significant role in enhancing and stabilizing the project.
 
 ## Credits
-Thanks to mikollysenko writing this informative article!
-https://0fps.net/2012/06/30/meshing-in-a-minecraft-game/
-And to the Bevy Community, for building an awesome project!
 
+Thanks to mikollysenko for writing this informative article!
+<https://0fps.net/2012/06/30/meshing-in-a-minecraft-game/>
+And to the Bevy Community, for building an awesome project!

--- a/examples/simple_example.rs
+++ b/examples/simple_example.rs
@@ -1,7 +1,7 @@
 //! An example that showcases how to use the meshem function.
 #[allow(unused_imports)]
 use bevy::pbr::wireframe::{Wireframe, WireframeConfig, WireframePlugin};
-use bevy::{color::palettes::css::{LIMEGREEN, SALMON}, prelude::*, text::cosmic_text::ttf_parser::Style};
+use bevy::{color::palettes::css::{LIMEGREEN, SALMON}, prelude::*};
 use bevy_meshem::prelude::*;
 
 /// Constants for us to use.
@@ -83,6 +83,7 @@ fn setup(
     .unwrap();
     let culled_mesh_handle: Handle<Mesh> = meshes.add(culled_mesh.clone());
     commands.spawn((
+        Mesh3d(culled_mesh_handle),
         MeshMaterial3d::from(materials.add(StandardMaterial {
                 base_color: Color::Srgba(SALMON),
                 alpha_mode: AlphaMode::Mask(0.5),
@@ -129,7 +130,7 @@ fn setup(
     //     if att == Mesh::ATTRIBUTE_POSITION.id {}
     // }
     commands.spawn((
-        Text2d::new(format!(
+        Text::new(format!(
             "X/Y/Z: Rotate\nR: Reset orientation\nMove Camera: W/A/S/D/Left-Shift/Space\nToggle Wireframe: T\n")),
         TextColor::from(LIMEGREEN),
         Node {
@@ -141,7 +142,7 @@ fn setup(
     ));
     commands.spawn((
         MeshInfo,
-        Text2d::new(format!("Press -C- To regenerate the mesh with a different Algorithm\nVertices Count: {}\nMeshing Algorithm: {:?}",culled_mesh.count_vertices(),
+        Text::new(format!("Press -C- To regenerate the mesh with a different Algorithm\nVertices Count: {}\nMeshing Algorithm: {:?}",culled_mesh.count_vertices(),
         MESHING_ALGORITHM,)),
         TextColor::from(LIMEGREEN),
         Node {
@@ -162,7 +163,7 @@ struct BlockRegistry {
 impl VoxelRegistry for BlockRegistry {
     /// The type of our Voxel, the example uses u16 for Simplicity but you may have a struct
     /// Block { Name: ..., etc ...}, and you'll define that as the type, but encoding the block
-    /// data onto simple type like u16 or u64 is probably prefferable.
+    /// data onto simple type like u16 or u64 is probably preferable.
     type Voxel = u16;
     /// The get_mesh function, probably the most important function in the
     /// [`VoxelRegistry`], it is what allows us to  quickly access the Mesh of each Voxel.
@@ -173,7 +174,7 @@ impl VoxelRegistry for BlockRegistry {
         VoxelMesh::NormalCube(&self.block)
     }
     /// Important function that tells our Algorithm if the Voxel is "full", for example, the Air
-    /// in minecraft is not "full", but it is still on the chunk data, to singal there is nothing.
+    /// in minecraft is not "full", but it is still on the chunk data, to signal there is nothing.
     fn is_covering(&self, voxel: &Self::Voxel, _side: prelude::Face) -> bool {
         return *voxel != 0;
     }
@@ -186,7 +187,7 @@ impl VoxelRegistry for BlockRegistry {
         return [1.0, 1.0, 1.0];
     }
     /// The attributes we want to take from out voxels, note that using a lot of different
-    /// attributes will likely lead to performance problems and unpredictible behaviour.
+    /// attributes will likely lead to performance problems and unpredictable behaviour.
     /// We chose these 3 because they are very common, the algorithm does preserve UV data.
     fn all_attributes(&self) -> Vec<bevy::render::mesh::MeshVertexAttribute> {
         return vec![
@@ -300,7 +301,7 @@ fn regenerate_mesh(
     mut meshes: ResMut<Assets<Mesh>>,
     mesh_query: Query<&Mesh3d>,
     mut event_reader: EventReader<RegenerateMesh>,
-    mut text_query: Query<&mut Text2d, With<MeshInfo>>,
+    mut text_query: Query<&mut Text, With<MeshInfo>>,
 ) {
     for _ in event_reader.read() {
         let mesh = meshes

--- a/examples/simple_example.rs
+++ b/examples/simple_example.rs
@@ -1,7 +1,7 @@
 //! An example that showcases how to use the meshem function.
 #[allow(unused_imports)]
 use bevy::pbr::wireframe::{Wireframe, WireframeConfig, WireframePlugin};
-use bevy::prelude::*;
+use bevy::{color::palettes::css::{LIMEGREEN, SALMON}, prelude::*, text::cosmic_text::ttf_parser::Style};
 use bevy_meshem::prelude::*;
 
 /// Constants for us to use.
@@ -83,15 +83,11 @@ fn setup(
     .unwrap();
     let culled_mesh_handle: Handle<Mesh> = meshes.add(culled_mesh.clone());
     commands.spawn((
-        PbrBundle {
-            mesh: culled_mesh_handle,
-            material: materials.add(StandardMaterial {
-                base_color: Color::SALMON,
+        MeshMaterial3d::from(materials.add(StandardMaterial {
+                base_color: Color::Srgba(SALMON),
                 alpha_mode: AlphaMode::Mask(0.5),
                 ..default()
-            }),
-            ..default()
-        },
+            })),
         Meshy {
             ma: MESHING_ALGORITHM,
             meta: metadata,
@@ -114,59 +110,46 @@ fn setup(
     );
 
     // Camera in 3D space.
-    commands.spawn(Camera3dBundle {
-        transform: camera_and_light_transform,
-        ..default()
-    });
+    commands.spawn((
+        Camera3d::default(),
+        camera_and_light_transform
+    ));
 
     // Light up the scene.
-    commands.spawn(PointLightBundle {
-        point_light: PointLight {
+    commands.spawn((
+        PointLight {
             intensity: 5000.0,
             range: 500.0,
             ..default()
         },
-        transform: camera_and_light_transform,
-        ..default()
-    });
+        camera_and_light_transform
+    ));
     // for (att, _val) in culled_mesh.attributes() {
     //     // dbg!(att);
     //     if att == Mesh::ATTRIBUTE_POSITION.id {}
     // }
-    commands.spawn(
-        TextBundle::from_section(
-            format!(
-                "X/Y/Z: Rotate\nR: Reset orientation\nMove Camera: W/A/S/D/Left-Shift/Space\nToggle Wireframe: T\n"),
-            TextStyle {
-                font_size: 26.0,
-                color: Color::LIME_GREEN,
-                ..default()
-            },
-        )
-        .with_style(Style {
+    commands.spawn((
+        Text2d::new(format!(
+            "X/Y/Z: Rotate\nR: Reset orientation\nMove Camera: W/A/S/D/Left-Shift/Space\nToggle Wireframe: T\n")),
+        TextColor::from(LIMEGREEN),
+        Node {
             position_type: PositionType::Absolute,
             top: Val::Px(12.0),
             left: Val::Px(12.0),
             ..default()
-        }),
-    );
+        },
+    ));
     commands.spawn((
         MeshInfo,
-        TextBundle::from_section(
-            format!("Press -C- To regenerate the mesh with a different Algorithm\nVertices Count: {}\nMeshing Algorithm: {:?}",culled_mesh.count_vertices(),
-                MESHING_ALGORITHM,),
-            TextStyle {
-                font_size: 26.0,
-                color: Color::LIME_GREEN,
-                ..default()
-            },
-        )
-        .with_style(Style {
+        Text2d::new(format!("Press -C- To regenerate the mesh with a different Algorithm\nVertices Count: {}\nMeshing Algorithm: {:?}",culled_mesh.count_vertices(),
+        MESHING_ALGORITHM,)),
+        TextColor::from(LIMEGREEN),
+        Node {
             position_type: PositionType::Absolute,
             bottom: Val::Px(12.0),
             left: Val::Px(12.0),
             ..default()
-        }),
+        },
     ));
 }
 
@@ -224,17 +207,17 @@ fn input_handler(
 ) {
     if keyboard_input.pressed(KeyCode::KeyX) {
         for mut transform in &mut query {
-            transform.rotate_x(time.delta_seconds() / 1.2);
+            transform.rotate_x(time.delta_secs() / 1.2);
         }
     }
     if keyboard_input.pressed(KeyCode::KeyY) {
         for mut transform in &mut query {
-            transform.rotate_y(time.delta_seconds() / 1.2);
+            transform.rotate_y(time.delta_secs() / 1.2);
         }
     }
     if keyboard_input.pressed(KeyCode::KeyZ) {
         for mut transform in &mut query {
-            transform.rotate_z(time.delta_seconds() / 1.2);
+            transform.rotate_z(time.delta_secs() / 1.2);
         }
     }
     if keyboard_input.pressed(KeyCode::KeyR) {
@@ -262,12 +245,12 @@ fn toggle_wireframe(
         if let Ok(ent) = with.get_single() {
             commands.entity(ent).remove::<Wireframe>();
             for (_, material) in materials.iter_mut() {
-                material.base_color.set_a(1.0);
+                material.base_color.set_alpha(1.0);
             }
         } else if let Ok(ent) = without.get_single() {
             commands.entity(ent).insert(Wireframe);
             for (_, material) in materials.iter_mut() {
-                material.base_color.set_a(0.0);
+                material.base_color.set_alpha(0.0);
             }
         }
     }
@@ -275,27 +258,27 @@ fn toggle_wireframe(
 
 fn input_handler_rotation(
     keyboard_input: Res<ButtonInput<KeyCode>>,
-    mut query: Query<&mut Transform, With<Camera>>,
+    mut query: Query<&mut Transform, With<Camera3d>>,
     time: Res<Time>,
 ) {
     let t = query.get_single_mut().unwrap().into_inner();
     if keyboard_input.pressed(KeyCode::Space) {
-        t.translation += Vec3::Y * SPEED * time.delta_seconds();
+        t.translation += Vec3::Y * SPEED * time.delta_secs();
     }
     if keyboard_input.pressed(KeyCode::ShiftLeft) {
-        t.translation += Vec3::NEG_Y * SPEED * time.delta_seconds();
+        t.translation += Vec3::NEG_Y * SPEED * time.delta_secs();
     }
     if keyboard_input.pressed(KeyCode::KeyS) {
-        t.translation += t.back() * SPEED * time.delta_seconds();
+        t.translation += t.back() * SPEED * time.delta_secs();
     }
     if keyboard_input.pressed(KeyCode::KeyW) {
-        t.translation += t.forward() * SPEED * time.delta_seconds();
+        t.translation += t.forward() * SPEED * time.delta_secs();
     }
     if keyboard_input.pressed(KeyCode::KeyA) {
-        t.translation += t.left() * SPEED * time.delta_seconds();
+        t.translation += t.left() * SPEED * time.delta_secs();
     }
     if keyboard_input.pressed(KeyCode::KeyD) {
-        t.translation += t.right() * SPEED * time.delta_seconds();
+        t.translation += t.right() * SPEED * time.delta_secs();
     }
     t.look_at(
         Vec3::new(
@@ -315,9 +298,9 @@ fn regenerate_mesh(
     mut meshy: Query<&mut Meshy>,
     breg: Res<BlockRegistry>,
     mut meshes: ResMut<Assets<Mesh>>,
-    mesh_query: Query<&Handle<Mesh>>,
+    mesh_query: Query<&Mesh3d>,
     mut event_reader: EventReader<RegenerateMesh>,
-    mut text_query: Query<&mut Text, With<MeshInfo>>,
+    mut text_query: Query<&mut Text2d, With<MeshInfo>>,
 ) {
     for _ in event_reader.read() {
         let mesh = meshes
@@ -343,7 +326,7 @@ fn regenerate_mesh(
         )
         .unwrap();
 
-        t.sections[0].value = format!("Press -C- To regenerate the mesh with a different Algorithm\nVertices Count: {}\nMeshing Algorithm: {:?}",mesh.count_vertices(),m.ma);
+        t.0 = format!("Press -C- To regenerate the mesh with a different Algorithm\nVertices Count: {}\nMeshing Algorithm: {:?}",mesh.count_vertices(),m.ma);
         return;
     }
 }

--- a/src/face.rs
+++ b/src/face.rs
@@ -12,7 +12,7 @@ pub enum Face {
 pub(crate) const OFFSET_CONST: u32 = 0b0001_1111_1111_1111_1111_1111_1111_1111;
 pub(crate) const REVERSE_OFFSET_CONST: u32 = 0b1110_0000_0000_0000_0000_0000_0000_0000;
 
-/// Funtion converts a `Face` into an its encoded representation for opcode.
+/// Function converts a `Face` into an its encoded representation for opcode.
 pub fn face_to_u32(f: Face) -> u32 {
     match f {
         // 101 -> 2^31 + 2^29
@@ -84,7 +84,7 @@ impl From<usize> for Face {
             3 => Face::Left,
             4 => Face::Back,
             5 => Face::Forward,
-            _ => panic!("Face can only be infered from 6 values, 0..5 (inclucive)"),
+            _ => panic!("Face can only be inferred from 6 values, 0..5 (inclusive)"),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ pub mod prelude {
 }
 
 /// Implementing this trait for your own data-structure is the most important
-/// prerequesite if you want to use the function.
+/// prerequisite if you want to use the function.
 pub trait VoxelRegistry {
     type Voxel: std::fmt::Debug + Eq + PartialEq + Sized + Clone + Copy;
     /// Returns None if the mesh is "irrelevant" as in it's air or not a Voxel.
@@ -38,7 +38,7 @@ pub trait VoxelRegistry {
     fn is_covering(&self, voxel: &Self::Voxel, side: prelude::Face) -> bool;
     /// The center of the voxel (physical center, the center of the default block is 0,0,0 eg)
     fn get_center(&self) -> [f32; 3];
-    /// All the voxels must have standard and equal dimesions (y is up).
+    /// All the voxels must have standard and equal dimensions (y is up).
     fn get_voxel_dimensions(&self) -> [f32; 3];
     /// The attributes we are considering while meshing the grid.
     fn all_attributes(&self) -> Vec<MeshVertexAttribute>;

--- a/src/meshem.rs
+++ b/src/meshem.rs
@@ -19,12 +19,12 @@ pub enum MeshingAlgorithm {
 ///     should we cull. ex: in Minecraft you wouldn't cull the top because the player can see the
 ///     top of the chunk. But culling the bottom is ok because the player "shouldn't be there" so
 ///     he won't see it.
-/// - [`grid`](&[T]): one dimentional slice of voxels, to turn into a single mesh, the function
-///     assumes the real grid is 3 dimentional, and that the width, height and length match the
+/// - [`grid`](&[T]): one dimensional slice of voxels, to turn into a single mesh, the function
+///     assumes the real grid is 3 dimensional, and that the width, height and length match the
 ///     dimensions given with the dims argument.
 /// - [`reg`](VoxelRegistry): this is a data structure that will return the desired mesh attribute
 ///     we need, but(!) the size of each of the voxels MUST be the same across the entire grid.
-///     if this condition is not met, the grid will not be properly meshified.
+///     if this condition is not met, the grid will not be properly meshed.
 ///     An example to create a [`VoxelRegistry`] is in the examples folder.
 /// - ['ma'](MeshingAlgorithm): The meshing algorithm to use - currently supports Culling and
 ///     Naive. (Culling is always better than Naive)
@@ -271,11 +271,11 @@ fn add_vertices_normal_cube(
     }
 
     // The code from now on is a little messy, but it is very simple in actuality. It is mostly
-    // just offseting the vertices and indices and formatting them into the right data-structres.
+    // just offsetting the vertices and indices and formatting them into the right data-structures.
 
     // offset the vertices, since we won't be using all the vertices of the the mesh,
     // we need to find out which of them we will be using first, and then filter out
-    // the ones we dont need.
+    // the ones we don't need.
     let mut offset: u32 = 0;
     for q in sorted_vertices.iter() {
         match q {

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,6 +1,6 @@
 // use crate::pbs::*;
 use crate::prelude::*;
-use bevy::render::mesh::{Indices, VertexAttributeValues};
+use bevy::render::mesh::{Indices, MeshVertexAttributeId, VertexAttributeValues};
 
 /// The function updates the mesh according to the change log in the mesh meta data.
 pub fn update_mesh<T: std::fmt::Debug>(
@@ -380,12 +380,12 @@ fn add_voxel_after_gen(
     }
     indices_main.extend(indices_to_save);
 
-    for (id, vals) in main_mesh.attributes_mut() {
+    for (attr, vals) in main_mesh.attributes_mut() {
         let mut att = voxel
-            .attribute(id)
-            .expect(format!("Couldn't retrieve voxel mesh attribute {:?}.", id).as_str())
+            .attribute(attr.id)
+            .expect(format!("Couldn't retrieve voxel mesh attribute {:?}.", attr.id).as_str())
             .get_needed(&final_vertices);
-        if id == Mesh::ATTRIBUTE_POSITION.id {
+        if attr.id == Mesh::ATTRIBUTE_POSITION.id {
             att = att.offset_all(position_offset);
         }
         vals.extend(&att);

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,6 +1,6 @@
 // use crate::pbs::*;
 use crate::prelude::*;
-use bevy::render::mesh::{Indices, MeshVertexAttributeId, VertexAttributeValues};
+use bevy::render::mesh::{Indices, VertexAttributeValues};
 
 /// The function updates the mesh according to the change log in the mesh meta data.
 pub fn update_mesh<T: std::fmt::Debug>(
@@ -348,7 +348,7 @@ fn add_voxel_after_gen(
     }
 
     // The code from now on is a little messy, but it is very simple in actuality. It is mostly
-    // just offseting the vertices and indices and formatting them into the right data-structres.
+    // just offsetting the vertices and indices and formatting them into the right data-structures.
 
     // offset the vertices, since we won't be using all the vertices of the the mesh,
     // we need to find out which of them we will be using first, and then filter out

--- a/src/util/vav.rs
+++ b/src/util/vav.rs
@@ -1,6 +1,6 @@
 //! Pretty hefty module, it defines a lot of needed methods on the VertexAttributeValues,
 //! that makes working with them more comfortable. It is very spaghetti but it helps with the
-//! readabillity of main API.
+//! readability of main API.
 #![allow(unused_variables)]
 use bevy::render::{mesh::VertexAttributeValues, render_resource::VertexFormat};
 pub trait VAVutils {


### PR DESCRIPTION
## Code changes
- Update Bevy dependency to version `0.15.0`, previously was version `0.13.0`.
  - At the time of writing, the latest version of Bevy is `0.15.0`.
- Updated both examples to correctly use this new version.
  - Some of the actions taken were based off of the [0.14 to 0.15 migration guide.](https://bevyengine.org/learn/migration-guides/0-14-to-0-15/)
## Grammar and Formatting
  - Corrected grammar in README.md.
  - Corrected grammar in various comments around the project.
  - Corrected grammar for variable `choise`, now `choice`.
  - Updated README.md formatting to better satisfy the [Markdownlint rules.](http://xiangxing98.github.io/Markdownlint_Rules.html)

I'm using this for a project and noticed all of this almost immediately, so I thought I'd help to leave it better than I found it.