### PR TITLE
Update to Bevy 1.18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_meshem"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 authors = ["Adamkob12"]
 description = "A crate that offers a flexible and efficient way to generate meshes from a grid of Voxels"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,5 @@ documentation = "https://docs.rs/bevy_meshem"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = "0.16.0"
+bevy = "0.18.0"
 rand = "0.8.5"

--- a/examples/simple_example.rs
+++ b/examples/simple_example.rs
@@ -23,14 +23,10 @@ fn main() {
             Some(0.8),
             1.0,
         ),
-    })
-    .insert_resource(AmbientLight {
-        brightness: 1500.0,
-        color: Color::WHITE,
-        ..default()
     });
 
-    app.add_systems(Startup, setup).add_systems(
+    app.add_systems(Startup, setup)
+        .add_systems(
         Update,
         (
             input_handler,
@@ -40,8 +36,8 @@ fn main() {
         ),
     );
 
-    app.add_event::<ToggleWireframe>()
-        .add_event::<RegenerateMesh>();
+    app.add_message::<ToggleWireframe>()
+        .add_message::<RegenerateMesh>();
 
     app.run();
 }
@@ -55,10 +51,10 @@ struct Meshy {
 #[derive(Component)]
 struct MeshInfo;
 
-#[derive(Event, Default)]
+#[derive(Message, Default)]
 struct ToggleWireframe;
 
-#[derive(Event, Default)]
+#[derive(Message, Default)]
 struct RegenerateMesh;
 
 /// Setting up everything to showcase the mesh.
@@ -109,6 +105,15 @@ fn setup(
             FACTOR as f32 * 0.5,
         ),
         Vec3::Y,
+    );
+
+    // Ambient Light
+    commands.spawn(
+        AmbientLight {
+                brightness: 1500.0,
+                color: Color::WHITE,
+                ..default()
+        }
     );
 
     // Camera in 3D space.
@@ -190,7 +195,7 @@ impl VoxelRegistry for BlockRegistry {
     /// The attributes we want to take from out voxels, note that using a lot of different
     /// attributes will likely lead to performance problems and unpredictable behaviour.
     /// We chose these 3 because they are very common, the algorithm does preserve UV data.
-    fn all_attributes(&self) -> Vec<bevy::render::mesh::MeshVertexAttribute> {
+    fn all_attributes(&self) -> Vec<bevy::mesh::MeshVertexAttribute> {
         return vec![
             Mesh::ATTRIBUTE_POSITION,
             Mesh::ATTRIBUTE_UV_0,
@@ -204,8 +209,8 @@ fn input_handler(
     keyboard_input: Res<ButtonInput<KeyCode>>,
     mut query: Query<&mut Transform, With<Meshy>>,
     time: Res<Time>,
-    mut event_writer: EventWriter<ToggleWireframe>,
-    mut e: EventWriter<RegenerateMesh>,
+    mut message_writer: MessageWriter<ToggleWireframe>,
+    mut e: MessageWriter<RegenerateMesh>,
 ) {
     if keyboard_input.pressed(KeyCode::KeyX) {
         for mut transform in &mut query {
@@ -228,7 +233,7 @@ fn input_handler(
         }
     }
     if keyboard_input.just_pressed(KeyCode::KeyT) {
-        event_writer.write_default();
+        message_writer.write_default();
     }
     if keyboard_input.just_pressed(KeyCode::KeyC) {
         e.write_default();
@@ -241,9 +246,9 @@ fn toggle_wireframe(
     mut materials: ResMut<Assets<StandardMaterial>>,
     with: Query<Entity, With<Wireframe>>,
     without: Query<Entity, (Without<Wireframe>, With<Meshy>)>,
-    mut events: EventReader<ToggleWireframe>,
+    mut messages: MessageReader<ToggleWireframe>,
 ) {
-    for _ in events.read() {
+    for _ in messages.read() {
         if let Ok(ent) = with.single() {
             commands.entity(ent).remove::<Wireframe>();
             for (_, material) in materials.iter_mut() {
@@ -301,10 +306,10 @@ fn regenerate_mesh(
     breg: Res<BlockRegistry>,
     mut meshes: ResMut<Assets<Mesh>>,
     mesh_query: Query<&Mesh3d>,
-    mut event_reader: EventReader<RegenerateMesh>,
+    mut message_reader: MessageReader<RegenerateMesh>,
     mut text_query: Query<&mut Text, With<MeshInfo>>,
 ) {
-    for _ in event_reader.read() {
+    for _ in message_reader.read() {
         let mesh = meshes
             .get_mut(mesh_query.single().unwrap())
             .expect("Couldn't get a mut ref to the mesh");

--- a/examples/simple_example.rs
+++ b/examples/simple_example.rs
@@ -107,19 +107,15 @@ fn setup(
         Vec3::Y,
     );
 
-    // Ambient Light
-    commands.spawn(
+    // Camera in 3D space.
+    commands.spawn((
+        Camera3d::default(),
+        camera_and_light_transform,
         AmbientLight {
                 brightness: 1500.0,
                 color: Color::WHITE,
                 ..default()
         }
-    );
-
-    // Camera in 3D space.
-    commands.spawn((
-        Camera3d::default(),
-        camera_and_light_transform
     ));
 
     // Light up the scene.

--- a/examples/update_mesh_example.rs
+++ b/examples/update_mesh_example.rs
@@ -145,17 +145,15 @@ fn setup(
         Vec3::Y,
     );
 
-    // Ambient Light
-    commands.spawn(AmbientLight {
-        brightness: 400.0,
-        color: Color::WHITE,
-        ..default()
-    });
-
     // Camera in 3D space.
     commands.spawn((
         Camera3d::default(),
-        camera_and_light_transform
+        camera_and_light_transform,
+        AmbientLight {
+            brightness: 400.0,
+            color: Color::WHITE,
+            ..default()
+        }
     ));
 
     // Light up the scene.

--- a/examples/update_mesh_example.rs
+++ b/examples/update_mesh_example.rs
@@ -49,11 +49,6 @@ fn main() {
     app.insert_resource(BlockRegistry {
         grass: mesh,
         dirt: mesh2,
-    })
-    .insert_resource(AmbientLight {
-        brightness: 400.0,
-        color: Color::WHITE,
-        ..default()
     });
 
     app.add_systems(Startup, setup).add_systems(
@@ -66,8 +61,8 @@ fn main() {
         ),
     );
 
-    app.add_event::<ToggleWireframe>()
-        .add_event::<RegenerateMesh>();
+    app.add_message::<ToggleWireframe>()
+        .add_message::<RegenerateMesh>();
 
     app.run();
 }
@@ -81,10 +76,10 @@ struct Meshy {
 #[derive(Component)]
 struct MeshInfo;
 
-#[derive(Event, Default)]
+#[derive(Message, Default)]
 struct ToggleWireframe;
 
-#[derive(Event, Default)]
+#[derive(Message, Default)]
 struct RegenerateMesh;
 
 /// Setting up everything to showcase the mesh.
@@ -149,6 +144,13 @@ fn setup(
         ),
         Vec3::Y,
     );
+
+    // Ambient Light
+    commands.spawn(AmbientLight {
+        brightness: 400.0,
+        color: Color::WHITE,
+        ..default()
+    });
 
     // Camera in 3D space.
     commands.spawn((
@@ -240,7 +242,7 @@ impl VoxelRegistry for BlockRegistry {
     /// The attributes we want to take from out voxels, note that using a lot of different
     /// attributes will likely lead to performance problems and unpredictable behaviour.
     /// We chose these 3 because they are very common, the algorithm does preserve UV data.
-    fn all_attributes(&self) -> Vec<bevy::render::mesh::MeshVertexAttribute> {
+    fn all_attributes(&self) -> Vec<bevy::mesh::MeshVertexAttribute> {
         return vec![
             Mesh::ATTRIBUTE_POSITION,
             Mesh::ATTRIBUTE_UV_0,
@@ -254,8 +256,8 @@ fn input_handler(
     keyboard_input: Res<ButtonInput<KeyCode>>,
     mut query: Query<&mut Transform, With<Meshy>>,
     time: Res<Time>,
-    mut event_writer: EventWriter<ToggleWireframe>,
-    mut e: EventWriter<RegenerateMesh>,
+    mut message_writer: MessageWriter<ToggleWireframe>,
+    mut e: MessageWriter<RegenerateMesh>,
 ) {
     if keyboard_input.pressed(KeyCode::KeyX) {
         for mut transform in &mut query {
@@ -278,7 +280,7 @@ fn input_handler(
         }
     }
     if keyboard_input.just_pressed(KeyCode::KeyT) {
-        event_writer.write_default();
+        message_writer.write_default();
     }
     if keyboard_input.pressed(KeyCode::KeyC) {
         e.write_default();
@@ -291,9 +293,9 @@ fn toggle_wireframe(
     mut materials: ResMut<Assets<StandardMaterial>>,
     with: Query<Entity, With<Wireframe>>,
     without: Query<Entity, (Without<Wireframe>, With<Meshy>)>,
-    mut events: EventReader<ToggleWireframe>,
+    mut messages: MessageReader<ToggleWireframe>,
 ) {
-    for _ in events.read() {
+    for _ in messages.read() {
         if let Ok(ent) = with.single() {
             commands.entity(ent).remove::<Wireframe>();
             for (_, material) in materials.iter_mut() {
@@ -351,9 +353,9 @@ fn mesh_update(
     breg: Res<BlockRegistry>,
     mut meshes: ResMut<Assets<Mesh>>,
     mesh_query: Query<&Mesh3d>,
-    mut event_reader: EventReader<RegenerateMesh>,
+    mut message_reader: MessageReader<RegenerateMesh>,
 ) {
-    for _ in event_reader.read() {
+    for _ in message_reader.read() {
         let mesh = meshes
             .get_mut(mesh_query.single().unwrap())
             .expect("Couldn't get a mut ref to the mesh");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,8 +8,8 @@ pub mod util;
 pub(crate) mod voxel_mesh;
 
 use bevy::log::warn;
+use bevy::mesh::MeshVertexAttribute;
 use bevy::prelude::*;
-use bevy::render::mesh::MeshVertexAttribute;
 
 pub mod prelude {
     pub use crate::adj::*;

--- a/src/meshem.rs
+++ b/src/meshem.rs
@@ -1,9 +1,9 @@
 //! This module contains the main functions themself, and some added utilities and defs.
 use crate::pbs::*;
 use crate::prelude::*;
+use bevy::asset::RenderAssetUsages;
 use bevy::prelude::*;
-use bevy::render::mesh::{Indices, MeshVertexAttribute, VertexAttributeValues};
-use bevy::render::render_asset::RenderAssetUsages;
+use bevy::mesh::{Indices, MeshVertexAttribute, VertexAttributeValues};
 use bevy::render::render_resource::PrimitiveTopology;
 
 /// All the variants for the Meshing algorithm.

--- a/src/pbs.rs
+++ b/src/pbs.rs
@@ -2,8 +2,7 @@
 /// voxel based games that resembles Ambient Occlusion, but it is static- which means the
 /// shadows are computed only once, when the mesh is generated (or updated).
 use crate::prelude::*;
-use bevy::math::Vec3;
-use bevy::render::mesh::{Mesh, VertexAttributeValues};
+use bevy::{math::Vec3, mesh::VertexAttributeValues};
 use std::sync::{Arc, RwLock};
 
 #[derive(Copy, Clone)]

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,6 +1,6 @@
 // use crate::pbs::*;
 use crate::prelude::*;
-use bevy::render::mesh::{Indices, VertexAttributeValues};
+use bevy::mesh::{Indices, VertexAttributeValues};
 
 /// The function updates the mesh according to the change log in the mesh meta data.
 pub fn update_mesh<T: std::fmt::Debug>(

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -154,7 +154,7 @@ pub const fn one_d_cords_safe(threed: [usize; 3], dims: (usize, usize, usize)) -
 }
 
 // Extract the vertex data for the physics engine.
-use bevy::render::mesh::{Mesh, VertexAttributeValues};
+use bevy::mesh::{Mesh, VertexAttributeValues};
 pub fn extract_position_vertex_data(mesh: &Mesh) -> Vec<Vec3> {
     let VertexAttributeValues::Float32x3(pos_vertices) =
         mesh.attribute(Mesh::ATTRIBUTE_POSITION).unwrap()
@@ -168,7 +168,7 @@ pub fn extract_position_vertex_data(mesh: &Mesh) -> Vec<Vec3> {
 }
 
 // Extract the indices for the physics engine.
-use bevy::render::mesh::Indices;
+use bevy::mesh::Indices;
 pub fn extract_indices_data(mesh: &Mesh) -> Vec<[u32; 3]> {
     let Indices::U32(indices) = mesh.indices().unwrap() else {
         panic!("Indices data shoud be in `Indices::U32` format")

--- a/src/util/vav.rs
+++ b/src/util/vav.rs
@@ -2,7 +2,9 @@
 //! that makes working with them more comfortable. It is very spaghetti but it helps with the
 //! readability of main API.
 #![allow(unused_variables)]
-use bevy::render::{mesh::VertexAttributeValues, render_resource::VertexFormat};
+use bevy::render::render_resource::VertexFormat;
+use bevy::mesh::VertexAttributeValues;
+
 pub trait VAVutils {
     fn extend(&mut self, t: &Self);
     fn filter_bool_array(&self, index_filter: Vec<bool>) -> Self;

--- a/src/voxel_mesh.rs
+++ b/src/voxel_mesh.rs
@@ -1,9 +1,9 @@
 //! A module containing the "default block", it is used in the examples,
 //! it is simple and easy to work with.
 use crate::prelude::*;
+use bevy::asset::RenderAssetUsages;
+use bevy::mesh::Indices;
 use bevy::prelude::*;
-use bevy::render::mesh::Indices;
-use bevy::render::render_asset::RenderAssetUsages;
 use bevy::render::render_resource::PrimitiveTopology;
 
 /// Function that generates the mesh of a voxel.


### PR DESCRIPTION
A minimal port of Meshem to Bevy 1.18.0

- Everything from `bevy::render::mesh::*` used in this library moved to `bevy::mesh::*` ([Migration Entry](https://bevy.org/learn/migration-guides/0-16-to-0-17/#bevy-render-reorganization))
- `RenderAssetUses` moved from `bevy::render::render_asset::RenderAssetUses` to `bevy::asset::RenderAssetUses` ([Migration Entry](https://bevy.org/learn/migration-guides/0-16-to-0-17/#bevy-render-reorganization))
- `Event`s are split into 2 different things. `Message`s and (new) `Event`s. `Message`s work the same as `Event`s used to be, so all old `Event`s, `EventWriter`s and `EventReader`s are now `Message`s, `MessageWriter`s, and `MessageReader`s ([Migration Entry](https://bevy.org/learn/migration-guides/0-16-to-0-17/#event-trait-split-rename))
- `AmbientLight` is no longer a `Resource`, but a `Component` for a `Camera` ([Migration Entry](https://bevy.org/learn/migration-guides/0-17-to-0-18/#ambientlight-split-into-a-component-and-a-resource)). An argument could be made that using the  `GlobalAmbientLight` resource would be a more faithful port.